### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-check-dependencies.yml
+++ b/.github/workflows/pr-check-dependencies.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   check-dependency-cache:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/LucienLeMagicien/pm2-exporter/security/code-scanning/3](https://github.com/LucienLeMagicien/pm2-exporter/security/code-scanning/3)

The best way to fix the issue is to add a `permissions:` block at the job level (under `check-dependency-cache`) or at the workflow level (top-level, after `name` and before `on`), explicitly specifying `contents: read`, which is the absolute minimum needed for checking out code. Since the workflow performs only source checkout and dependency verification, it does not need write permissions. The addition should go immediately above or below the `runs-on:` line (job-level) or after the workflow `name:` (workflow-level). No external libraries or packages are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
