### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   dagger:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Clone repository


### PR DESCRIPTION
Potential fix for [https://github.com/LucienLeMagicien/pm2-exporter/security/code-scanning/2](https://github.com/LucienLeMagicien/pm2-exporter/security/code-scanning/2)

To address the issue, add an explicit `permissions` block at the workflow or job level. Since there is only one job (`dagger`), it's simplest and effective to add a `permissions:` block in the job specification, just above `runs-on`. The minimal safe starting point according to the recommendation is `contents: read`, which allows read-only access to repository contents (which is required for actions/checkout to work). This change should be applied to the `.github/workflows/docker.yml` file within the `dagger:` job definition. No further imports, methods, or other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
